### PR TITLE
PoC: Added a hard error when incorrect database connection is used

### DIFF
--- a/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
+++ b/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Ibexa\Bundle\Test\Core\DependencyInjection\CompilerPass;
+
+use Ibexa\Contracts\CorePersistence\Gateway\AbstractDoctrineDatabase;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class PersistenceCheckCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!class_exists(AbstractDoctrineDatabase::class)) {
+            return;
+        }
+
+        foreach ($container->getDefinitions() as $definitionId => $definition) {
+            $class = $definition->getClass();
+
+            if ($class === null) {
+                continue;
+            }
+
+            if (!is_a($class, AbstractDoctrineDatabase::class, true)) {
+                continue;
+            }
+
+            $argument = (string)$this->getConnectionArgument($definition);
+            if ($argument !== 'ibexa.persistence.connection') {
+                throw new \LogicException(sprintf(
+                    'Service definition "%s" contains reference to "%s" as connection argument. '
+                    . 'Expected "%s". This will cause issues in multi-repository setups.',
+                    $definitionId,
+                    $argument,
+                    'ibexa.persistence.connection',
+                ));
+            }
+        }
+    }
+
+    private function getConnectionArgument(Definition $definition): Reference
+    {
+        try {
+            return $definition->getArgument('$connection');
+        } catch (OutOfBoundsException $e) {
+            return $definition->getArgument(0);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
+++ b/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Bundle\Test\Core\DependencyInjection\CompilerPass;
 
 use Ibexa\Contracts\CorePersistence\Gateway\AbstractDoctrineDatabase;

--- a/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
+++ b/src/bundle/DependencyInjection/CompilerPass/PersistenceCheckCompilerPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Reference;
 
-class PersistenceCheckCompilerPass implements CompilerPassInterface
+final class PersistenceCheckCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/bundle/DependencyInjection/IbexaTestCoreExtension.php
+++ b/src/bundle/DependencyInjection/IbexaTestCoreExtension.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Test\Core\DependencyInjection;
 
+use Ibexa\Bundle\Test\Core\DependencyInjection\CompilerPass\PersistenceCheckCompilerPass;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -28,5 +30,7 @@ final class IbexaTestCoreExtension extends Extension
         );
 
         $loader->load('services.yaml');
+
+        $container->addCompilerPass(new PersistenceCheckCompilerPass(), PassConfig::TYPE_AFTER_REMOVING);
     }
 }


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | N/A |
| **Type**                       | feature                               |
| **Target eZ Platform version** |                 |
| **BC breaks**                  | yes/no                                                |
| **Doc needed**                 | yes/no                                                |

This adds a Compiler Pass that detects when non-multirepository connection is used against instances of `AbstractDoctrineDatabase` services.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Asked for a review (ping `@ibexa/engineering`).
