### PR TITLE
Fixed generating `%kernel.project_dir%/templates` directory

### DIFF
--- a/src/contracts/IbexaTestKernel.php
+++ b/src/contracts/IbexaTestKernel.php
@@ -151,6 +151,7 @@ class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
+            self::setTwigDefaultPath($container);
             $container->setParameter('ibexa.core.test.resource_dir', self::getResourcesPath());
         });
 
@@ -278,5 +279,14 @@ class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
         $definition = new Definition($class);
         $definition->setSynthetic(true);
         $container->setDefinition($id, $definition);
+    }
+
+    protected static function setTwigDefaultPath(ContainerBuilder $container): void
+    {
+        $kernelProjectDir = $container->getParameter('kernel.project_dir');
+        if (!is_string($kernelProjectDir)) {
+            throw new LogicException('%kernel.project_dir% container parameter needs to be a string');
+        }
+        $container->setParameter('twig.default_path', $kernelProjectDir . '/var/templates');
     }
 }


### PR DESCRIPTION
While executing locally integration tests, some packages generate dummy `%kernel.project_dir%/templates` directory. I've tracked it down to https://github.com/ibexa/design-engine/blob/v4.5.4/src/bundle/DependencyInjection/Compiler/TwigThemePass.php (applies to v3.3 as well).
We're probably gonna remove that statement there as it's obsolete and redundant (recipes create that directory anyway).

That said, for now, let's also define `twig.default_path` as `./var/templates` with respect to the actual project dir (which is package root in integration tests). Might be useful in general.