### PR TITLE
[Tests] Dropped providing fallback Test Kernel if not defined

### DIFF
--- a/src/contracts/IbexaKernelTestCase.php
+++ b/src/contracts/IbexaKernelTestCase.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Test\Core;
 
 use Ibexa\Contracts\Core\Test\IbexaTestKernelInterface;
-use LogicException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -18,15 +17,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 abstract class IbexaKernelTestCase extends KernelTestCase
 {
     private IbexaTestCoreInterface $ibexaCore;
-
-    protected static function getKernelClass(): string
-    {
-        try {
-            return parent::getKernelClass();
-        } catch (LogicException $e) {
-            return IbexaTestKernel::class;
-        }
-    }
 
     protected function getIbexaTestCore(): IbexaTestCoreInterface
     {


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | n/a |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v5.0`              |
| **BC breaks**            | yes                                              |

Returning default core Kernel if none was defined has proven to cause debugging issues when someone forgets to define it but expect his kernel is actually being the one used.

The idea behind this adjustment to Symfony Test Kernel was to help with simpler setups, however in practice simpler setup is never used, because each kernel needs to define at least its own bundle.

Therefore removing it. If kernel was not configured, it will cause a LogicException when running tests. If indeed for some edge case a custom kernel is not needed, one can simply mitigate the issue by explicitly configuring `KERNEL_CLASS` as `Ibexa\Contracts\Test\Core\IbexaTestKernel`.

### TODO

- [ ] Try using multi-repo tools to check integration tests for all relevant 1st party packages.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
