### PR TITLE
Formatted composer.json using JQ --indent 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,61 +1,61 @@
 {
-  "name": "ibexa/test-core",
-  "license": "proprietary",
-  "type": "ibexa-bundle",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "doctrine/dbal": "^2.13.0",
-    "symfony/framework-bundle": "^5.4",
-    "symfony/mime": "^5.4",
-    "symfony/proxy-manager-bridge": "^5.4",
-    "symfony/translation": "^5.4",
-    "symfony/validator": "^5.4",
-    "symfony/yaml": "^5.4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9",
-    "ibexa/code-style": "^1.1",
-    "ibexa/core": "~4.5.x-dev",
-    "ibexa/doctrine-schema": "~4.5.x-dev",
-    "phpstan/phpstan": "^1.2",
-    "phpstan/phpstan-phpunit": "^1.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Ibexa\\Bundle\\Test\\Core\\": "src/bundle/",
-      "Ibexa\\Contracts\\Test\\Core\\": "src/contracts/",
-      "Ibexa\\Test\\Core\\": "src/lib/"
+    "name": "ibexa/test-core",
+    "license": "proprietary",
+    "type": "ibexa-bundle",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "doctrine/dbal": "^2.13.0",
+        "symfony/framework-bundle": "^5.4",
+        "symfony/mime": "^5.4",
+        "symfony/proxy-manager-bridge": "^5.4",
+        "symfony/translation": "^5.4",
+        "symfony/validator": "^5.4",
+        "symfony/yaml": "^5.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9",
+        "ibexa/code-style": "^1.1",
+        "ibexa/core": "~4.5.x-dev",
+        "ibexa/doctrine-schema": "~4.5.x-dev",
+        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan-phpunit": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ibexa\\Bundle\\Test\\Core\\": "src/bundle/",
+            "Ibexa\\Contracts\\Test\\Core\\": "src/contracts/",
+            "Ibexa\\Test\\Core\\": "src/lib/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ibexa\\Tests\\Bundle\\Test\\Core\\": "tests/bundle/",
+            "Ibexa\\Tests\\Integration\\Test\\Core\\": "tests/integration/",
+            "Ibexa\\Tests\\Test\\Core\\": "tests/lib/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "4.5.x-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": false,
+        "sort-packages": true
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Ibexa\\Tests\\Bundle\\Test\\Core\\": "tests/bundle/",
-      "Ibexa\\Tests\\Integration\\Test\\Core\\": "tests/integration/",
-      "Ibexa\\Tests\\Test\\Core\\": "tests/lib/"
-    }
-  },
-  "scripts": {
-    "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
-    "check-cs": "@fix-cs --dry-run",
-    "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon"
-  },
-  "scripts-descriptions": {
-    "fix-cs": "Automatically fixes code style in all files",
-    "check-cs": "Run code style checker for all files",
-    "test": "Run automatic tests",
-    "phpstan": "Run static code analysis"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-main": "4.5.x-dev"
-    }
-  },
-  "config": {
-    "allow-plugins": false,
-    "sort-packages": true
-  }
 }


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | n/a |
| **Type**                       | improvement                               |
| **Target Ibexa version** | `v4.5`+                |
| **BC breaks**                  | no                                                |

Aligned indent of `composer.json` to 4 spaces, for consistency's sake with the pre-existing conventions, ease of merge-ups and task automation.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.