### PR TITLE
Added utility class to ignore SA configuration

### DIFF
--- a/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
+++ b/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
@@ -20,9 +20,6 @@ final class IgnoredConfigParser extends AbstractParser
     /** @var string[] */
     private array $keys;
 
-    /**
-     * @param string[] $keys
-     */
     public function __construct(string ...$keys)
     {
         $this->keys = $keys;

--- a/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
+++ b/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
@@ -23,7 +23,7 @@ final class IgnoredConfigParser extends AbstractParser
     /**
      * @param string[] $keys
      */
-    public function __construct(array $keys)
+    public function __construct(string ...$keys)
     {
         $this->keys = $keys;
     }

--- a/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
+++ b/src/contracts/DependencyInjection/Configuration/SiteAccessAware/IgnoredConfigParser.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Test\Core\DependencyInjection\Configuration\SiteAccessAware;
+
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\AbstractParser;
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * SA configuration parser which allows ignoring given keys in tests.
+ */
+final class IgnoredConfigParser extends AbstractParser
+{
+    /** @var string[] */
+    private array $keys;
+
+    /**
+     * @param string[] $keys
+     */
+    public function __construct(array $keys)
+    {
+        $this->keys = $keys;
+    }
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        foreach ($this->keys as $key) {
+            $nodeBuilder->variableNode($key)->defaultNull()->end();
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $scopeSettings
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+    }
+}


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | N/A |
| **Type**                 | feature                             |
| **Target Ibexa version** | `v4.6` |
| **BC breaks**            | no                                              |

Added utility class to ignore SA configuration. Usage:

```php
final class IbexaTestKernel extends BaseIbexaTestKernel
{
    # ...

    public function registerContainerConfiguration(LoaderInterface $loader): void
    {
        $loader->load(static function (ContainerBuilder $container): void {
            /** @var \Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension $ibexa */
            $ibexa = $container->getExtension('ibexa');
            $ibexa->addConfigParser(new IgnoredConfigParser([
                'admin_ui_forms',
                'content_create_view',
                'content_translate_view',
                'content_edit_view',
                'limitation_value_templates',
                'universal_discovery_widget_module',
                'page_builder_forms',
                'design',
                'user_registration',
            ]));
        });
    }

    #...
}
```


### Background

IgnoredConfigParser class was originally created for product catalog and since then copied into several other packages:

![image](https://github.com/ibexa/test-core/assets/211967/33810258-8d41-4d98-a17e-165ea7f649a5)

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
