### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "ibexa/code-style": "^1.1",
+        "ibexa/code-style": "^2.0",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "ibexa/rector": "~5.0.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ibexa/code-style": "^1.1",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0"
     },

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
+    ]);

--- a/src/contracts/Translation/TranslationService.php
+++ b/src/contracts/Translation/TranslationService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Test\Core\Translation;
 
 use JMS\TranslationBundle\Translation\Comparison\ChangeSet;
+use JMS\TranslationBundle\Translation\Config;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
 use Twig\Environment;
@@ -63,7 +64,7 @@ final class TranslationService
         $this->updater->process($config);
     }
 
-    private function getConfig(string $configName): \JMS\TranslationBundle\Translation\Config
+    private function getConfig(string $configName): Config
     {
         $this->configureHandlerForMissingTwig();
 
@@ -79,21 +80,25 @@ final class TranslationService
             return;
         }
 
-        $this->twigEnvironment->registerUndefinedFunctionCallback(function (string $name): ?TwigFunction {
-            if ($this->functions === null || in_array($name, $this->functions, true)) {
-                return new TwigFunction($name, static fn (): string => '');
+        $this->twigEnvironment->registerUndefinedFunctionCallback(
+            function (string $name): TwigFunction|false {
+                if ($this->functions === null || in_array($name, $this->functions, true)) {
+                    return new TwigFunction($name, static fn (): string => '');
+                }
+
+                return false;
             }
+        );
 
-            return null;
-        });
+        $this->twigEnvironment->registerUndefinedFilterCallback(
+            function (string $name): TwigFilter|false {
+                if ($this->filters === null || in_array($name, $this->filters, true)) {
+                    return new TwigFilter($name, static fn ($value) => $value);
+                }
 
-        $this->twigEnvironment->registerUndefinedFilterCallback(function (string $name): ?TwigFilter {
-            if ($this->filters === null || in_array($name, $this->filters, true)) {
-                return new TwigFilter($name, static fn ($value) => $value);
+                return false;
             }
-
-            return null;
-        });
+        );
 
         $this->twigConfigured = true;
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x. Added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
