### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
     "require": {
         "php": ">=8.3",
         "doctrine/dbal": "^3.7.0",
-        "symfony/framework-bundle": "^7.2",
-        "symfony/mime": "^7.2",
-        "symfony/translation": "^7.2",
-        "symfony/validator": "^7.2",
-        "symfony/yaml": "^7.2"
+        "symfony/framework-bundle": "^7.3",
+        "symfony/mime": "^7.3",
+        "symfony/translation": "^7.3",
+        "symfony/validator": "^7.3",
+        "symfony/yaml": "^7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

