### PR TITLE
IBX-11844: Made translation test data provider PHPUnit 12 compatible

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,3 +5,9 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/contracts/IbexaTestCore.php
+
+		-
+			message: '#^Attribute class PHPUnit\\Framework\\Attributes\\DataProvider does not exist\.$#'
+			identifier: attribute.notFound
+			count: 1
+			path: src/contracts/Translation/AbstractTranslationCase.php

--- a/src/contracts/Translation/AbstractTranslationCase.php
+++ b/src/contracts/Translation/AbstractTranslationCase.php
@@ -11,6 +11,7 @@ namespace Ibexa\Contracts\Test\Core\Translation;
 use Ibexa\Contracts\Test\Core\IbexaKernelTestCase;
 use JMS\TranslationBundle\Model\Message;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 abstract class AbstractTranslationCase extends IbexaKernelTestCase
 {
@@ -22,6 +23,7 @@ abstract class AbstractTranslationCase extends IbexaKernelTestCase
     /**
      * @dataProvider provideConfigNamesForTranslation
      */
+    #[DataProvider('provideConfigNamesForTranslation')]
     final public function testTranslation(string $configName): void
     {
         $facade = $this->getTranslationService();


### PR DESCRIPTION
| :ticket: Issue | IBX-11844 |
|----------------|-----------|

#### Description:

PHPUnit 12 no longer reads data providers from annotations, which caused translation integration tests to run without provider arguments.

Added `DataProvider` attribute to `AbstractTranslationCase::testTranslation()` while keeping the existing `@dataProvider` annotation for backward compatibility.

Validation:
- Verified with `phpunit/phpunit 12.5.29` in `ibexa/permissions`
- Verified with `phpunit/phpunit 9.5.0` in `ibexa/fieldtype-matrix`
